### PR TITLE
Fix code scanning alert no. 1: Clear text storage of sensitive information

### DIFF
--- a/Ocaramba.Tests.PageObjects/PageObjects/TheInternet/FormAuthenticationPage.cs
+++ b/Ocaramba.Tests.PageObjects/PageObjects/TheInternet/FormAuthenticationPage.cs
@@ -72,7 +72,7 @@ namespace Ocaramba.Tests.PageObjects.PageObjects.TheInternet
 
         public void EnterPassword(string password)
         {
-            Logger.Info(CultureInfo.CurrentCulture, "Password '{0}'", password);
+            Logger.Info(CultureInfo.CurrentCulture, "Password '{0}'", new string('*', password.Length));
             this.Driver.GetElement(this.passwordForm).SendKeys(password);
             this.Driver.WaitForAjax();
         }


### PR DESCRIPTION
Fixes [https://github.com/Accenture/Ocaramba/security/code-scanning/1](https://github.com/Accenture/Ocaramba/security/code-scanning/1)

To fix the problem, we should avoid logging the password in clear text. Instead, we can log a placeholder or a masked version of the password to indicate that a password was entered without exposing the actual value. This change should be made in the `EnterPassword` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
